### PR TITLE
fix: comma missing in const list

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -1,7 +1,7 @@
 const
   letter = /[a-zA-Z]/,
-  decimal_digit = /[0-9]/
-  octal_digit = /[0-7]/
+  decimal_digit = /[0-9]/,
+  octal_digit = /[0-7]/,
   hex_digit = /[0-9A-Fa-f]/
 
 function array_of(content) {
@@ -157,7 +157,7 @@ module.exports = grammar({
     field: $ => seq(
       // This isn't allowed according to the spec and yet the proto3 compiler
       // accepts it so we put it here for parsing.
-      optional(choice('optional','required')),
+      optional(choice('optional', 'required')),
 
       optional('repeated'),
       $.type,


### PR DESCRIPTION
Evaluating the grammar in `strict mode` fails, because there are some variables being assigned as globals. This is because there are missing commas after each variable.